### PR TITLE
fix(distrobuilder): remove invalid targets.incus.create_message

### DIFF
--- a/distrobuilder/debian-bookworm.yaml
+++ b/distrobuilder/debian-bookworm.yaml
@@ -8,12 +8,6 @@ source:
   downloader: debootstrap
   url: http://deb.debian.org/debian
 
-targets:
-  lxc:
-    create_message: "Base image built"
-  incus:
-    create_message: "Base image built"
-
 packages:
   manager: apt
   update: true
@@ -36,3 +30,4 @@ packages:
         - libssl3
         - libsqlite3-0
         - libgdiplus
+


### PR DESCRIPTION
## Summary
- remove outdated `targets` block from distrobuilder debian config

## Testing
- `python3 - <<'PY'
import yaml
with open('distrobuilder/debian-bookworm.yaml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689bbd4debf88323befa1fec21608f57